### PR TITLE
RubyMotion run script alteration

### DIFF
--- a/rubymotion_run.sh
+++ b/rubymotion_run.sh
@@ -13,22 +13,13 @@ try
     tell application "Terminal"
         activate
         try
-						close (every window whose custom title is "${TERMINAL_ID}")
 						close (every window whose custom title is "rake")
-	          do script "cd \"${PROJECT_DIR}\""
-
+						delay 0.5
+		        do script "cd \"${PROJECT_DIR}\""
+				    do script "rake ${OPTIONS}" in front window
 				on error errs number errn
 						display dialog errs & return & "Error: " & (errn as string)
-            do script "alias quit='' && cd \"${PROJECT_DIR}\" && clear"
         end try
-    		
-				delay 0.1
-
-		    tell window 1
-		        set custom title to "${TERMINAL_ID}"
-		    end tell
-
-		    do script "rake ${OPTIONS}" in front window
 	    end tell
 end try
 END


### PR DESCRIPTION
Altered run script as it didn't actually work. 

Problems were:
- didn't close previous window (issue is that custom title did not remain as "${TERMINAL_ID}" but would change to "rake" when rake executed, so the window would never be found or closed.
- sometimes didn't run rake, but simply ran the following and did nothing else:
  alias quit='' && cd \"${PROJECT_DIR}\" && clear

This commit not perfect (not skilled at osascript) but now works.

Problems:
- will close every rake instance running in Terminal.app. Basically reporting a bug and a crude fix, but my osascript skills are too low to perfect it
