### PR TITLE
add description about configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,15 @@ These two commands also supported in Command Pallet.
 
 * `RubyMotionBuilder: Generate syntax` will generate syntax and snippets from Ruby syntax.
 * `RubyMotionBuilder: Generate completions` will generate completions from BridgeSupport files of RubyMotion.
+
+Configuration
+-----
+If you want to do `Build`, `Clean` and `Deploy` with specific path, Add option to configuration file such as following..
+
+    {
+        "rubymotion_build_env_file": "$HOME/.bash_profile"
+    }
+
+The configuration file is here.
+
+    ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/User/RubyMotion.sublime-settings


### PR DESCRIPTION
When I user Bundler, Build was failed with following message.

```
rake aborted!
no such file to load -- bundler/setup
```

But SublimeRubyMotionBuilder had prepared me a nice option thankfully.

I think it should be written to the README for everyone to be happy :smile:
