### PR TITLE
Fix GenerateRubyMotionSyntax to work with sublime text 3

### DIFF
--- a/RubyMotionBuilder.py
+++ b/RubyMotionBuilder.py
@@ -115,7 +115,10 @@ class RubyMotionDoc(sublime_plugin.WindowCommand):
 
 class GenerateRubyMotionSyntax(sublime_plugin.WindowCommand):
     def run(self):
-        rb_name = os.path.join(this_dir, "rubymotion_syntax_generator.rb")
+        if int(sublime.version()) // 1000 == 3:
+            rb_name = os.path.join(this_dir, "rubymotion_syntax_generator3.rb")
+        else:
+            rb_name = os.path.join(this_dir, "rubymotion_syntax_generator2.rb")
         self.window.run_command("exec", {"cmd": ["ruby", rb_name], "working_dir": this_dir})
 
 

--- a/rubymotion_syntax_generator2.rb
+++ b/rubymotion_syntax_generator2.rb
@@ -22,7 +22,7 @@ Dir.foreach("../Ruby") do |file_name|
     next if ext == ".cache"
 
     # Ruby.* rename to RubyMotion.*
-    base = File.basename(file_name, ext) 
+    base = File.basename(file_name, ext)
     base = "RubyMotion" if base == "Ruby"
 
     # skip ignore file

--- a/rubymotion_syntax_generator3.rb
+++ b/rubymotion_syntax_generator3.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby -wKU
+
+require "stringio"
+begin
+  require 'zip'
+rescue LoadError => e
+  STDERR.puts 'rubyzip is required. Run "gem install rubyzip"'
+end
+
+DebugEnabled = true
+
+ignore_files = [
+  "RubyMotion.tmLanguage",
+  "Default.sublime-commands",
+  "Default.sublime-keymap",
+  "RubyMotion.sublime-build",
+  "RubyMotion.sublime-settings"
+]
+
+ruby_package_file = '/Applications/Sublime Text.app/Contents/MacOS/Packages/Ruby.sublime-package'
+
+Zip::File.foreach(ruby_package_file) do |zip|
+  next if zip.ftype != :file
+
+  file_name = zip.name
+  # skip cache files
+  ext = File.extname(file_name)
+  next if ext == ".cache"
+
+  # Ruby.* rename to RubyMotion.*
+  base = File.basename(file_name, ext)
+  base = "RubyMotion" if base == "Ruby"
+
+  # skip ignore file
+  next if ignore_files.include?(base + ext)
+
+  dst_file_name = base + ext
+  STDERR.puts "Creating: #{dst_file_name}" if DebugEnabled
+
+  uuid = ">#{`uuidgen`.chomp}<"
+  iobuf = StringIO.open
+
+  begin
+    tmpfile_path = "/tmp/#{file_name}"
+    zip.extract(tmpfile_path)
+    File.open(tmpfile_path, "r") do |in_file|
+
+      skip = false
+      in_file.each do |line|
+        # ignore lines
+        skip = false if skip and line =~ /<key>/
+        skip = true if line =~ />(fileTypes|firstLineMatch)</
+        next if skip
+
+        line = line.gsub(/>Ruby</, ">RubyMotion<")
+        line = line.gsub(/source\.ruby([< ])/, "source.rubymotion\\1")
+        line = line.gsub(/>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}</, uuid)
+
+        iobuf.puts line
+
+      end # in_file.each
+
+    end # File.open of in_file
+
+    File.open(dst_file_name, "w") do |out_file|
+      out_file.puts iobuf.string
+    end  # File.open of out_file
+  rescue
+    STDERR.puts " -> FAILED: #{$!.backtrace.first} : #{$!}" if DebugEnabled
+
+  ensure
+    File.unlink(tmpfile_path) if File.exist?(tmpfile_path)
+  end
+
+  iobuf.close
+end


### PR DESCRIPTION
I fixed `Generate syntax` function to work with Sublime Text 3.
This will require rubyzip gem to be installed.
