### PR TITLE
Improved run file

### DIFF
--- a/rubymotion_run.sh
+++ b/rubymotion_run.sh
@@ -28,7 +28,7 @@ if [ "${TERMINAL_APP}" = "iTerm" ]; then
             select current_session
 
             tell current_session
-                if (name is "ruby" or name is "rake" or name is "sim") then 
+                if ("ruby" is in name or "rake" is in name or "sim" is in name) then 
                     write text "exit"
                 end if
 


### PR DESCRIPTION
Sometimes the name of my session is "(ruby)" instead of "ruby" and sometimes it's "bundle rake" instead of "rake". I don't fully understand why, but this line makes the exit command work again.

We simply check if "ruby" is in the name instead of check if it is the name.
