### PR TITLE
Take spaces in folder names into account

### DIFF
--- a/rubymotion_run.sh
+++ b/rubymotion_run.sh
@@ -32,7 +32,7 @@ if [ "${TERMINAL_APP}" = "iTerm" ]; then
                     write text "exit"
                 end if
 
-                write text "cd ${PROJECT_DIR}"
+                write text "cd '${PROJECT_DIR}'"
                 write text "${RAKE}"
             end tell
         end tell


### PR DESCRIPTION
If you have a space in one of your folder names, sublime motion builder currently doesn't cd into it. Therefore the quotations around the path.
